### PR TITLE
only searching in .hidden-phone QuickLinks for notifications

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -27,7 +27,7 @@ function getTextNodeContentOnly($it) {
 }
 
 cnUtil.parseContent = function(content) {
-	var select = $(content).find('ul.nav-list .badge');
+	var select = $(content).find('.hidden-phone ul.nav-list .badge');
 	var count = 0;
 	var summary = {};
 	var notifications = summary.notifications = [];


### PR DESCRIPTION
Hab die select-query angepasst, weil anscheinend ein zweites QuickLink-Menü for Mobile-Devices dazu gekommen ist.

Dadurch sind alle Notifications doppelt angezeigt worden.
